### PR TITLE
Update step.yml

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -8,6 +8,14 @@ website: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator
 source_code_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid
 support_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid/issues
 
+project_type_tags:
+  - ios
+  - react-native
+  - flutter
+  - cordova
+  - ionic
+  - xamarin
+
 type_tags:
   - utility
 


### PR DESCRIPTION
Add project_type_tags.

### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

unified-ci started to fail for this step. The issue is caused by the missing `project_type_tags` property of the step. 
Without defining the supported project types, unified-ci starts worker builds on Linux stacks as well, which fails with error:

```
Input:
- SimulatorPlatform: iOS Simulator
- SimulatorDevice: iPhone 8
- SimulatorOsVersion: 14.5

attempt 0 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 1 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 2 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 3 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
Error: simulator UDID lookup failed: exec: "xcrun": executable file not found in $PATH
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- add `project_type_tags` property to the step.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
