### PR TITLE
Update step.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .bitrise*
+.idea/

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -4,12 +4,29 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
   test_udid:
+    before_run:
+    - _expose_xcode_version
     steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+
+            if [[ ${XCODE_MAJOR_VERSION} -eq 10 ]]; then
+              envman add --key "SIMULATOR_OS_VERSION" --value "12.4"
+            elif [[ ${XCODE_MAJOR_VERSION} -eq 11 ]]; then
+              envman add --key "SIMULATOR_OS_VERSION" --value "13.6"
+            elif [[ ${XCODE_MAJOR_VERSION} -eq 12 ]]; then
+              envman add --key "SIMULATOR_OS_VERSION" --value "14.5"
+            elif [[ ${XCODE_MAJOR_VERSION} -eq 13 ]]; then
+              envman add --key "SIMULATOR_OS_VERSION" --value "15.0"
+            fi
     - path::./:
         title: Test Step
         inputs:
-        - simulator_device: iPhone 8
-        - simulator_os_version: "14.5"
+        - simulator_device: "iPhone 8"
+        - simulator_os_version: $SIMULATOR_OS_VERSION
     - script:
         inputs:
         - content: |-
@@ -18,4 +35,26 @@ workflows:
               echo "XCODE_SIMULATOR_UDID not exported"
               exit 1
             fi
+
+  _expose_xcode_version:
+    steps:
+      - script:
+          title: Expose Xcode major version
+          inputs:
+            - content: |-
+                #!/bin/env bash
+                set -e
+                if [[ ! -z "$XCODE_MAJOR_VERSION" ]]; then
+                  echo "Xcode major version already exposed: $XCODE_MAJOR_VERSION"
+                  exit 0
+                fi
+                version=`xcodebuild -version`
+                regex="Xcode ([0-9]*)."
+                if [[ ! $version =~ $regex ]]; then
+                  echo "Failed to determine Xcode major version"
+                  exit 1
+                fi
+                xcode_major_version=${BASH_REMATCH[1]}
+                echo "Xcode major version: $xcode_major_version"
+                envman add --key XCODE_MAJOR_VERSION --value $xcode_major_version
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -18,7 +18,7 @@ workflows:
             elif [[ ${XCODE_MAJOR_VERSION} -eq 11 ]]; then
               envman add --key "SIMULATOR_OS_VERSION" --value "13.6"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 12 ]]; then
-              envman add --key "SIMULATOR_OS_VERSION" --value "14.5"
+              envman add --key "SIMULATOR_OS_VERSION" --value "14.4"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 13 ]]; then
               envman add --key "SIMULATOR_OS_VERSION" --value "15.0"
             fi

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -14,7 +14,8 @@ workflows:
         inputs:
         - content: |-
             set -ex 
-            if [[ "$XCODE_SIMULATOR_UDID" != "D99575AF-303B-458C-8EDD-67921A4F4975" ]]; then
+            if [[ -z "$XCODE_SIMULATOR_UDID" ]]; then
+              echo "XCODE_SIMULATOR_UDID not exported"
               exit 1
             fi
 

--- a/step.yml
+++ b/step.yml
@@ -8,6 +8,14 @@ website: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator
 source_code_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid
 support_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid/issues
 
+project_type_tags:
+  - ios
+  - react-native
+  - flutter
+  - cordova
+  - ionic
+  - xamarin
+
 type_tags:
   - utility
 


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

unified-ci started to fail for this step. The issue is caused by the missing `project_type_tags` property of the step. 
Without defining the supported project types, unified-ci starts worker builds on Linux stacks as well, which fails with error:

```
Input:
- SimulatorPlatform: iOS Simulator
- SimulatorDevice: iPhone 8
- SimulatorOsVersion: 14.5

attempt 0 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 1 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 2 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
attempt 3 to get simulator udid failed with error: exec: "xcrun": executable file not found in $PATH
Error: simulator UDID lookup failed: exec: "xcrun": executable file not found in $PATH
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- add `project_type_tags` property to the step.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
