### PR TITLE
Use destination instead of simulator_* inputs

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -36,16 +36,16 @@ func NewSimulator(destination string) (*Simulator, error) {
 		case os:
 			simulator.OS = value
 		default:
-			return nil, fmt.Errorf("could not parse key \"%s\" with value \"%s\" in destination: %s", key, value, destination)
+			return nil, fmt.Errorf(`could not parse key "%s" with value "%s" in destination: %s`, key, value, destination)
 		}
 	}
 
 	if simulator.Platform == "" {
-		return nil, fmt.Errorf("missing key \"platform\" in destination: %s", destination)
+		return nil, fmt.Errorf(`missing key "platform" in destination: %s`, destination)
 	}
 
 	if simulator.Name == "" {
-		return nil, fmt.Errorf("missing key \"name\" in destination: %s", destination)
+		return nil, fmt.Errorf(`missing key "name" in destination: %s`, destination)
 	}
 
 	if simulator.OS == "" {

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -11,12 +11,14 @@ const (
 	os       = "OS"
 )
 
+// Simulator ...
 type Simulator struct {
 	Platform string
 	Name     string
 	OS       string
 }
 
+// NewSimulator ...
 func NewSimulator(destination string) (*Simulator, error) {
 	simulator := Simulator{}
 	destinationParts := strings.Split(destination, ",")

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -1,0 +1,55 @@
+package destination
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	platform = "platform"
+	name     = "name"
+	os       = "OS"
+)
+
+type Simulator struct {
+	Platform string
+	Name     string
+	OS       string
+}
+
+func NewSimulator(destination string) (*Simulator, error) {
+	simulator := Simulator{}
+	destinationParts := strings.Split(destination, ",")
+
+	for _, part := range destinationParts {
+		keyAndValue := strings.Split(part, "=")
+		key := keyAndValue[0]
+		value := keyAndValue[1]
+
+		switch key {
+		case platform:
+			simulator.Platform = value
+		case name:
+			simulator.Name = value
+		case os:
+			simulator.OS = value
+		default:
+			return nil, fmt.Errorf("could not parse key \"%s\" with value \"%s\" in destination: %s", key, value, destination)
+		}
+	}
+
+	if simulator.Platform == "" {
+		return nil, fmt.Errorf("missing key \"platform\" in destination: %s", destination)
+	}
+
+	if simulator.Name == "" {
+		return nil, fmt.Errorf("missing key \"name\" in destination: %s", destination)
+	}
+
+	if simulator.OS == "" {
+		// OS=latest can be omitted in the destination specifier, because it's the default value.
+		simulator.OS = "latest"
+	}
+
+	return &simulator, nil
+}

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -25,6 +25,11 @@ func NewSimulator(destination string) (*Simulator, error) {
 
 	for _, part := range destinationParts {
 		keyAndValue := strings.Split(part, "=")
+
+		if len(keyAndValue) != 2 {
+			return nil, fmt.Errorf(`could not parse "%s" because it is not a valid key=value pair in destination: %s`, keyAndValue, destination)
+		}
+
 		key := keyAndValue[0]
 		value := keyAndValue[1]
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -14,19 +14,18 @@ workflows:
             set -e
 
             if [[ ${XCODE_MAJOR_VERSION} -eq 10 ]]; then
-              envman add --key "SIMULATOR_OS_VERSION" --value "12.4"
+              envman add --key "DESTINATION" --value "platform=iOS Simulator,name=iPhone 8,OS=latest"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 11 ]]; then
-              envman add --key "SIMULATOR_OS_VERSION" --value "13.6"
+              envman add --key "DESTINATION" --value "platform=iOS Simulator,name=iPhone 8 Plus,OS=latest"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 12 ]]; then
-              envman add --key "SIMULATOR_OS_VERSION" --value "14.4"
+              envman add --key "DESTINATION" --value "platform=iOS Simulator,name=iPhone 11,OS=latest"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 13 ]]; then
-              envman add --key "SIMULATOR_OS_VERSION" --value "15.0"
+              envman add --key "DESTINATION" --value "platform=iOS Simulator,name=iPhone 12,OS=latest"
             fi
     - path::./:
         title: Test Step
         inputs:
-        - simulator_device: "iPhone 8"
-        - simulator_os_version: $SIMULATOR_OS_VERSION
+        - destination: $DESTINATION
     - script:
         inputs:
         - content: |-
@@ -38,23 +37,23 @@ workflows:
 
   _expose_xcode_version:
     steps:
-      - script:
-          title: Expose Xcode major version
-          inputs:
-            - content: |-
-                #!/bin/env bash
-                set -e
-                if [[ ! -z "$XCODE_MAJOR_VERSION" ]]; then
-                  echo "Xcode major version already exposed: $XCODE_MAJOR_VERSION"
-                  exit 0
-                fi
-                version=`xcodebuild -version`
-                regex="Xcode ([0-9]*)."
-                if [[ ! $version =~ $regex ]]; then
-                  echo "Failed to determine Xcode major version"
-                  exit 1
-                fi
-                xcode_major_version=${BASH_REMATCH[1]}
-                echo "Xcode major version: $xcode_major_version"
-                envman add --key XCODE_MAJOR_VERSION --value $xcode_major_version
+    - script:
+        title: Expose Xcode major version
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ! -z "$XCODE_MAJOR_VERSION" ]]; then
+              echo "Xcode major version already exposed: $XCODE_MAJOR_VERSION"
+              exit 0
+            fi
+            version=`xcodebuild -version`
+            regex="Xcode ([0-9]*)."
+            if [[ ! $version =~ $regex ]]; then
+              echo "Failed to determine Xcode major version"
+              exit 1
+            fi
+            xcode_major_version=${BASH_REMATCH[1]}
+            echo "Xcode major version: $xcode_major_version"
+            envman add --key XCODE_MAJOR_VERSION --value $xcode_major_version
 

--- a/step.yml
+++ b/step.yml
@@ -9,15 +9,15 @@ source_code_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-s
 support_url: https://github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid/issues
 
 project_type_tags:
-  - ios
-  - react-native
-  - flutter
-  - cordova
-  - ionic
-  - xamarin
+- ios
+- react-native
+- flutter
+- cordova
+- ionic
+- xamarin
 
 type_tags:
-  - utility
+- utility
 
 is_always_run: false
 is_skippable: false
@@ -27,55 +27,14 @@ toolkit:
     package_name: github.com/bitrise-steplib/bitrise-step-look-up-xcode-simulator-udid
 
 inputs:
-  - simulator_device: iPhone 8 Plus
+- destination:
     opts:
-      title: "Device"
-      description: |-
-        Set it as it is shown in Xcode's device selection dropdown UI.
-
-        A couple of examples (the
-        actual available options depend on which versions
-        are installed):
-
-        * iPhone 8 Plus
-        * iPhone Xs Max
-        * iPad Air (3rd generation)
-        * iPad Pro (12.9-inch) (3rd generation)
-        * Apple TV 4K (don't forget to set the platform to `tvOS Simulator` to use this option!)
-      is_required: true
-  - simulator_os_version: latest
-    opts:
-      title: "OS version"
-      description: |-
-        Set it as it is shown in
-        Xcode's device selection dropdown UI.
-
-        A couple of format examples (the
-        actual available options depend on which versions
-        are installed):
-
-        * 8.4
-        * latest
-      is_required: true
-  - simulator_platform: iOS Simulator
-    opts:
-      title: Platform
-      description: |-
-        Set it as it is shown in Xcode's device selection dropdown UI.
-
-        A couple of examples (the
-        actual available options depend on which versions
-        are installed):
-
-        * iOS Simulator
-        * tvOS Simulator
-      value_options:
-      - iOS Simulator
-      - tvOS Simulator
+      title: Device destination specifier
+      summary: Destination specifier describes the device to use as a destination.
       is_required: true
 
 outputs:
-  - XCODE_SIMULATOR_UDID:
-    opts:
-      title: "Xcode Simulator UDID"
-      summary: UDID of the matching Xcode Simulator
+- XCODE_SIMULATOR_UDID:
+  opts:
+    title: "Xcode Simulator UDID"
+    summary: UDID of the matching Xcode Simulator

--- a/step.yml
+++ b/step.yml
@@ -28,10 +28,10 @@ toolkit:
 
 inputs:
 - destination:
-    opts:
-      title: Device destination specifier
-      summary: Destination specifier describes the device to use as a destination.
-      is_required: true
+  opts:
+    title: Device destination specifier
+    summary: Destination specifier describes the device to use as a destination.
+    is_required: true
 
 outputs:
 - XCODE_SIMULATOR_UDID:


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MAJOR* [version update](https://semver.org/).
* Note: the step is not released yet.

### Context
* We are releasing a new major version of the Xcode Test step, where `simulator_*` inputs are replaced by `destination`.
* This step is used as a helper in Xcode Test's E2E tests.
* Because Xcode Test's inputs are changing, we need to change this step too.

### Changes
* Replace `simulator_*` inputs with `destination`.
